### PR TITLE
Diffusers 0.6.0 - StableDiffusionOnnxPipeline has changed to OnnxStableDiffusionPipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ If the model is on the hugging face website and it's using the diffusers library
 If the pretrained model is a `.ckpt` file, then you'll need to do a two step conversion. You first will need to convert from .ckpt to diffusers, then from diffusers to ONNX.
 
 Download the following files and the `.ckpt` model of your choice and put them in your working folder:  
-<https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_original_stable_diffusion_to_diffusers.py>  
+<https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_original_stable_diffusion_to_diffusers.py>
+<https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_stable_diffusion_checkpoint_to_onnx.py>
 <https://raw.githubusercontent.com/CompVis/stable-diffusion/main/configs/stable-diffusion/v1-inference.yaml>
 
 Run the first conversion script, using trinart2_step115000.ckpt in this example:  

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ If the model is on the hugging face website and it's using the diffusers library
 If the pretrained model is a `.ckpt` file, then you'll need to do a two step conversion. You first will need to convert from .ckpt to diffusers, then from diffusers to ONNX.
 
 Download the following files and the `.ckpt` model of your choice and put them in your working folder:  
-<https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_original_stable_diffusion_to_diffusers.py>
-<https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_stable_diffusion_checkpoint_to_onnx.py>
-<https://raw.githubusercontent.com/CompVis/stable-diffusion/main/configs/stable-diffusion/v1-inference.yaml>
+- <https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_original_stable_diffusion_to_diffusers.py>
+- <https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_stable_diffusion_checkpoint_to_onnx.py>
+- <https://raw.githubusercontent.com/CompVis/stable-diffusion/main/configs/stable-diffusion/v1-inference.yaml>
 
 Run the first conversion script, using trinart2_step115000.ckpt in this example:  
 `python convert_original_stable_diffusion_to_diffusers.py --checkpoint_path="./trinart2_step115000.ckpt" --dump_path="./trinart2_step115000_diffusers"`  

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ If the model is on the hugging face website and it's using the diffusers library
 If the pretrained model is a `.ckpt` file, then you'll need to do a two step conversion. You first will need to convert from .ckpt to diffusers, then from diffusers to ONNX.
 
 Download the following files and the `.ckpt` model of your choice and put them in your working folder:  
-- <https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_original_stable_diffusion_to_diffusers.py>
-- <https://raw.githubusercontent.com/huggingface/diffusers/b9eea06e9fd0d00aedd1948db972a13f7110367d/scripts/convert_stable_diffusion_checkpoint_to_onnx.py>
-- <https://raw.githubusercontent.com/CompVis/stable-diffusion/main/configs/stable-diffusion/v1-inference.yaml>
+- https://github.com/huggingface/diffusers/blob/main/scripts/convert_original_stable_diffusion_to_diffusers.py
+- https://github.com/huggingface/diffusers/blob/main/scripts/convert_stable_diffusion_checkpoint_to_onnx.py
+- https://raw.githubusercontent.com/CompVis/stable-diffusion/main/configs/stable-diffusion/v1-inference.yaml
 
 Run the first conversion script, using trinart2_step115000.ckpt in this example:  
 `python convert_original_stable_diffusion_to_diffusers.py --checkpoint_path="./trinart2_step115000.ckpt" --dump_path="./trinart2_step115000_diffusers"`  

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A lot of this document is based on other guides. I've listed them below:
 - https://www.travelneil.com/stable-diffusion-windows-amd.html
 - https://gist.github.com/harishanand95/75f4515e6187a6aa3261af6ac6f61269#file-stable_diffusion-md
 - https://rentry.org/ayymd-stable-diffustion-v1_4-guide
+- https://gist.github.com/averad/256c507baa3dcc9464203dc14610d674
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -50,21 +50,13 @@ First, update `pip`:
 
 Install the following packages:  
 ```
-pip install diffusers==0.5.1
+pip install diffusers
 pip install transformers
 pip install onnxruntime
 pip install onnx
+pip install onnxruntime-directml
 pip install torch
 ```
-
-Go to <https://aiinfra.visualstudio.com/PublicPackages/_artifacts/feed/ORT-Nightly/PyPI/ort-nightly-directml/overview/> and download the latest version of DirectML for your version of Python. Save the file into your working folder.  
-> If you are on Python 3.7 download the file that ends with **-cp37-cp37m-win_amd64.whl  
-> If you are on Python 3.8 download the file that ends with **-cp38-cp38-win_amd64.whl  
-> If you are on Python 3.9 download the file that ends with **-cp39-cp39-win_amd64.whl  
-> If you are on Python 3.10 download the file that ends with **-cp310-cp310-win_amd64.whl  
-
-Install the downloaded file using `pip`. Note the `--force-reinstall` is needed:  
-`pip install ort_nightly_<whatever_version_you_got>.whl --force-reinstall`
 
 ## Download Model and Convert to ONNX
 

--- a/README.md
+++ b/README.md
@@ -64,16 +64,16 @@ Login to huggingface:
 `huggingface-cli.exe login`  
 When it prompts you for your token, copy and paste your token from the huggingface website then press enter. NOTE: when pasting, the command prompt looks like nothing has happened. This is normal behaviour, just press enter and it should update.
 
-Go to <https://huggingface.co/CompVis/stable-diffusion-v1-4> and accept the terms for the model.
+Go to <https://huggingface.co/runwayml/stable-diffusion-v1-5> and accept the terms for the model.
 
-Go to <https://raw.githubusercontent.com/huggingface/diffusers/75bb6d2d466d742feb1e2be15f74d2605d11f0e9/scripts/convert_stable_diffusion_checkpoint_to_onnx.py> and download the script. Save the file into your working folder. NOTE: make sure you save this as a `.py` file and not as `.py.txt`.
-
-Run the Python script to download and convert:  
-`python convert_stable_diffusion_checkpoint_to_onnx.py --model_path="CompVis/stable-diffusion-v1-4" --output_path="./stable_diffusion_onnx"`
+Run the following Git command to download and convert:  
+```bash
+git clone https://huggingface.co/runwayml/stable-diffusion-v1-5 --branch onnx --single-branch stable_diffusion_onnx
+```
 
 ## Basic Script and Setup Check
 
-Download <https://raw.githubusercontent.com/azuritecoin/OnnxDiffusersUI/main/txt2img_onnx.py> and save the file into your working folder.
+Download <https://github.com/averad/OnnxDiffusersUI/blob/main/txt2img_onnx.py> and save the file into your working folder.
 
 Run the Python script and check if any images were generated in the output folder. NOTE: some warnings may show up but it should be working as long as an output image is generated:  
 `python txt2img_onnx.py`
@@ -86,7 +86,7 @@ If an image was generated and it's not just a blank image then you're ready to g
 Install the gradio package:  
 `pip install gradio`
 
-Download <https://raw.githubusercontent.com/azuritecoin/OnnxDiffusersUI/main/onnxUI.py> and save the file into your working folder.
+Download <https://github.com/averad/OnnxDiffusersUI/blob/main/onnxUI.py> and save the file into your working folder.
 Run the Python script and wait for everything to load:  
 `python onnxUI.py`
 

--- a/onnxUI.py
+++ b/onnxUI.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 
-from diffusers import StableDiffusionOnnxPipeline, DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
+from diffusers import OnnxStableDiffusionPipeline, DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
 import diffusers
 import gradio as gr
 import numpy as np
@@ -126,7 +126,7 @@ if __name__ == "__main__":
             set_alpha_to_one=False)
     else:
         raise Exception(f"Does not support scheduler with name {args.scheduler}.")
-    pipe = StableDiffusionOnnxPipeline.from_pretrained(
+    pipe = OnnxStableDiffusionPipeline.from_pretrained(
         model_path, provider="DmlExecutionProvider", scheduler=scheduler)
     pipe.safety_checker = lambda images, **kwargs: (images, [False] * len(images))  # Disable the safety checker
 

--- a/txt2img_onnx.py
+++ b/txt2img_onnx.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 
-from diffusers import StableDiffusionOnnxPipeline, PNDMScheduler
+from diffusers import OnnxStableDiffusionPipeline, PNDMScheduler
 import numpy as np
 
 
@@ -30,7 +30,7 @@ parser.add_argument("--seed", dest="seed", default="", help="seed for the genera
 args = parser.parse_args()
 
 scheduler = PNDMScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear")
-pipe = StableDiffusionOnnxPipeline.from_pretrained(
+pipe = OnnxStableDiffusionPipeline.from_pretrained(
     args.model_path, provider="DmlExecutionProvider", scheduler=scheduler)
 pipe.safety_checker = lambda images, **kwargs: (images, [False] * len(images))  # Disable the safety checker
 


### PR DESCRIPTION
As of Diffusers 0.6.0
StableDiffusionOnnxPipeline has changed to OnnxStableDiffusionPipeline

Code Examples: https://gist.github.com/averad/256c507baa3dcc9464203dc14610d674
Img2Img is working as well as Inpainting, not implemented in GUI