### PR TITLE
adjust steps for img2img & legacy inpaint

### DIFF
--- a/onnxUI.py
+++ b/onnxUI.py
@@ -274,14 +274,16 @@ def generate_click(
         input_mask = image_t2["mask"].convert("RGB")
         input_mask = resize_and_crop(input_mask, height_t2, width_t2)
         
-        # adjust steps to account for legacy inpaint only using 80% of set steps.
+        # adjust steps to account for legacy inpaint only using ~80% of set steps.
         if legacy_t2 is True:
             steps_t2_old = steps_t2
-            steps_t2 = int(steps_t2 / 0.8)
+            if steps_t2 < 5:
+                steps_t2 = steps_t2 + 1
+            elif steps_t2 >= 5:
+                steps_t2 = int((steps_t2 / 0.7989) + 1)
             print()
             print(f"Adjusting steps for legacy inpaint. From {steps_t2_old} to {steps_t2} internally.")
-            print(f"Without adjustment the actual step count would be ~{ceil(steps_t2_old * 0.8)} steps.")
-            print(f"Will only run {steps_t2_old} steps in actuality though. IDK what causes it. Quick fix.")
+            print(f"Without adjustment the actual step count would be ~{int(steps_t2_old * 0.80)} steps.")
             print()
 
         images, status = run_diffusers(

--- a/onnxUI.py
+++ b/onnxUI.py
@@ -259,10 +259,30 @@ def generate_click(
         # adjust steps to account for denoise.
         steps_t1_old = steps_t1
         steps_t1 = ceil(steps_t1 / denoise_t1)
-        print()
-        print(f"Adjusting steps to account for denoise. From {steps_t1_old} to {steps_t1} steps internally.")
-        print(f"Without adjustment the actual step count would be ~{ceil(steps_t1_old * denoise_t1)} steps.")
-        print()
+        if steps_t1 > 1000 and sch_t1 == "DPMS":
+            steps_t1_unreduced = steps_t1
+            steps_t1 = 1000
+            print()
+            print(
+                f"Adjusting steps to account for denoise. From {steps_t1_old} to {steps_t1_unreduced} steps internally."
+            )
+            print(
+                f"Without adjustment the actual step count would be ~{ceil(steps_t1_old * denoise_t1)} steps."
+            )
+            print()
+            print(
+                f"INTERNAL STEP COUNT EXCEEDS 1000 MAX FOR DPMS. INTERNAL STEPS WILL BE REDUCED TO 1000."
+            )
+            print()
+        else:
+            print()
+            print(
+                f"Adjusting steps to account for denoise. From {steps_t1_old} to {steps_t1} steps internally."
+            )
+            print(
+                f"Without adjustment the actual step count would be ~{ceil(steps_t1_old * denoise_t1)} steps."
+            )
+            print()
 
         images, status = run_diffusers(
             prompt_t1, neg_prompt_t1, input_image, None, iter_t1, batch_t1, steps_t1, guid_t1, height_t1, width_t1,
@@ -282,8 +302,12 @@ def generate_click(
             elif steps_t2 >= 5:
                 steps_t2 = int((steps_t2 / 0.7989) + 1)
             print()
-            print(f"Adjusting steps for legacy inpaint. From {steps_t2_old} to {steps_t2} internally.")
-            print(f"Without adjustment the actual step count would be ~{int(steps_t2_old * 0.80)} steps.")
+            print(
+                f"Adjusting steps for legacy inpaint. From {steps_t2_old} to {steps_t2} internally."
+            )
+            print(
+                f"Without adjustment the actual step count would be ~{int(steps_t2_old * 0.8)} steps."
+            )
             print()
 
         images, status = run_diffusers(


### PR DESCRIPTION
Legacy inpaint uses ~80% of set steps, so I adjusted it as closely as I could. I tested on a bunch of different step counts ranging from 2 to 150+ and it seems to work every time. Although the adjustment method may need to be changed to be more accurate. 

img2img will reduce steps using the de noise value. I adjusted that as well, and if using DPMS scheduler it caps how much it can adjust as it fails over 1000 steps (`ValueError: only one element tensors can be converted to Python scalars` scheduling_dpmsolver_multistep.py line 461). 11 steps at 0.01 de noise adjusts to 1100 steps so at 0.01 de noise you could only ever get 10 steps when using DPMS. Using another scheduler like EulerA works fine though.

So now if you set your steps in legacy inpaint to say; 102 steps, you do 102 steps, not ~82 steps. 
If you set your steps in img2img to say; 45 steps at 0.5 de noise, you do 45 steps, not ~23 steps. 

It'll say "internal step count", but what I mean by that is just the step count needed for the steps that SD does to match what you set in the UI.