### PR TITLE
Tweak setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy
 ftfy
 OmegaConf
 spacy
+numpy<1.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ftfy
 OmegaConf
 spacy
 numpy<1.24
+accelerate

--- a/setup.bat
+++ b/setup.bat
@@ -30,14 +30,13 @@ if exist %venv_path%\Scripts\activate.bat goto ActivateVirtEnv
 
 echo no %venv_path% folder detected, creating virtual environment
 set first_run=1
-python -m venv %venv_path%
+python -m venv %venv_path% --upgrade-deps
 
 :ActivateVirtEnv
 call %venv_path%\Scripts\activate.bat
 
 :: for the first run, get requirements and install packages
 if %first_run%==0 goto ScriptDownload
-python -m pip install --upgrade pip
 pip install wheel
 :: using wget from python library instead of standalone wget for Windows
 pip install wget


### PR DESCRIPTION
Hugging Face Diffusers only recently [removed 'np.float'](https://github.com/huggingface/diffusers/pull/1789) which had been deprecated; until the next version of Diffusers is released, the easiest solution is to avoid using numpy>=1.24

I see no harm in using --upgrade-deps (added in Python 3.9) given the suggested Python is already 3.10. And upgrading setuptools as well is NBD.

The accelerate library should speed up model loading and reduce RAM use, or so claim the messages the existing version produces.