### PR TITLE
ability to de-allocate pipeline when changing pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ VRAM memory pressure will reduce the speed of every iteration. It can be benefic
 You can make the UI load the Text Encoder on CPU by adding `--cpu-textenc` flag:  
 `python onnxUI.py --cpu-textenc`
 
+## De-allocate memory after each image generation
+You can de-allocate memory after each image generation in case you want to do that. Might be useful for very low VRAM.
+
+You can de-allocate memory after each generation by adding `--release-memory-after-generation` flag:
+`python onnxUI.py --release-memory-after-generation`
+
+## De-allocate memory when changing pipelines
+You can de-allocate memory when swapping pipelines (txt2img, img2img, inpaint). With low VRAM sometimes you may want to do this to prevent slowdowns or OOM errors that may occur from having multiple loaded at once. With more than 8GB of VRAM this is possibly not needed.
+
+You can de-allocate memory when swapping pipelines by adding `--release-memory-on-change` flag:
+`python onnxUI.py --release-memory-on-change`
+
 ## Running Stable Diffusion on CPUs
 
 If you don't have a graphics card with enough VRAM or you only have onboard graphics, you can still run Stable Diffusion with the CPU. Simply add a `--cpu-only` flag to your command line:  

--- a/onnxUI.py
+++ b/onnxUI.py
@@ -302,7 +302,8 @@ def generate_click(
     global current_tab
     global current_pipe
     global current_legacy
-    global release_memory
+    global release_memory_after_generation
+    global release_memory_on_change
     global scheduler
     global pipe
 
@@ -346,6 +347,9 @@ def generate_click(
 
     # select which pipeline depending on current tab
     if current_tab == 0:
+        if current_pipe == ("img2img" or "inpaint") and release_memory_on_change:
+            pipe = None
+            gc.collect()
         if current_pipe != "txt2img" or pipe is None:
             if textenc_on_cpu and vaedec_on_cpu:
                 cputextenc = OnnxRuntimeModel.from_pretrained(
@@ -385,6 +389,9 @@ def generate_click(
                     scheduler=scheduler)
         current_pipe = "txt2img"
     elif current_tab == 1:
+        if current_pipe == ("txt2img" or "inpaint") and release_memory_on_change:
+            pipe = None
+            gc.collect()
         if current_pipe != "img2img" or pipe is None:
             if textenc_on_cpu and vaedec_on_cpu:
                 cputextenc = OnnxRuntimeModel.from_pretrained(
@@ -420,6 +427,9 @@ def generate_click(
                     scheduler=scheduler)
         current_pipe = "img2img"
     elif current_tab == 2:
+        if current_pipe == ("txt2img" or "img2img") and release_memory_on_change:
+            pipe = None
+            gc.collect()
         if current_pipe != "inpaint" or pipe is None or current_legacy != legacy_t2:
             if legacy_t2:
                 if textenc_on_cpu and vaedec_on_cpu:
@@ -649,8 +659,12 @@ if __name__ == "__main__":
         "--cpu-vaedec", action="store_true",
         help="Run VAE Decoder on CPU, saves VRAM by running VAE Decoder on CPU")
     parser.add_argument(
-        "--release-memory", action="store_true", default=False,
+        "--release-memory-after-generation", action="store_true", default=False,
         help="de-allocate the pipeline and release memory after generation")
+    parser.add_argument(
+        "--release-memory-on-change", action="store_true", default=True,
+        help="de-allocate the pipeline and release memory allocated when changing pipelines",
+    )
     args = parser.parse_args()
 
     # variables for ONNX pipelines
@@ -659,7 +673,8 @@ if __name__ == "__main__":
     current_tab = 0
     current_pipe = "txt2img"
     current_legacy = False
-    release_memory = args.release_memory
+    release_memory_after_generation = args.release_memory_after_generation
+    release_memory_on_change = args.release_memory_on_change
     textenc_on_cpu = args.cpu_textenc
     vaedec_on_cpu = args.cpu_vaedec
 

--- a/onnxUI.py
+++ b/onnxUI.py
@@ -653,16 +653,16 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="gradio interface for ONNX based Stable Diffusion")
     parser.add_argument("--cpu-only", action="store_true", default=False, help="run ONNX with CPU")
     parser.add_argument(
-        "--cpu-textenc", action="store_true",
+        "--cpu-textenc", action="store_true", default=False,
         help="Run Text Encoder on CPU, saves VRAM by running Text Encoder on CPU")
     parser.add_argument(
-        "--cpu-vaedec", action="store_true",
+        "--cpu-vaedec", action="store_true", default=False,
         help="Run VAE Decoder on CPU, saves VRAM by running VAE Decoder on CPU")
     parser.add_argument(
         "--release-memory-after-generation", action="store_true", default=False,
         help="de-allocate the pipeline and release memory after generation")
     parser.add_argument(
-        "--release-memory-on-change", action="store_true", default=True,
+        "--release-memory-on-change", action="store_true", default=False,
         help="de-allocate the pipeline and release memory allocated when changing pipelines",
     )
     args = parser.parse_args()


### PR DESCRIPTION
with more than 8gb of vram it probably works fine and allows for quick switching. my gpu cant though and gets filled and either OOM or gets really slow (step time and my actual pc), so i added this.

i've also renamed `release_memory` to `release_memory_after_generation` to avoid confusion with this addition, and added info about these into the readme.

as with the other arguments, its off by default and you can set it using `--release-memory-on-change`.

i also added the defaults to the other arguments.