### PR TITLE
add ability to upload a custom inpaint mask, and also save the painted mask

### DIFF
--- a/onnxUI.py
+++ b/onnxUI.py
@@ -666,6 +666,7 @@ def generate_click(
             0,
             seed_t0,
             fmt_t0,
+            False,
             None,
             False,
         )
@@ -717,6 +718,7 @@ def generate_click(
             denoise_t1,
             seed_t1,
             fmt_t1,
+            False,
             None,
             loopback_t1,
         )


### PR DESCRIPTION
example mask, white area is ignored, black is generated on.
![000475-00  mask](https://user-images.githubusercontent.com/16216325/219864447-7fa1350c-001b-42bd-8b63-b97b67b90695.png)

gradio doesnt seem to support rgba, so the mask needs to be a white background with black being the masked out area. if you select the `save painted mask` button below the `legacy inpaint` button, it will save a mask in this format, and it can be loaded again by uploading it to the UI.

if you upload a mask it will use that instead of the painted mask.

masks get saved into a `masks` subfolder within the `output` folder, and should also contain the same metadata as the generated image, and will be named in the same format as the generated image with ` masks` added to the end.