### PR TITLE
use nearest neighbor instead of bicubic for resize_and_crop

### DIFF
--- a/onnxUI.py
+++ b/onnxUI.py
@@ -315,17 +315,25 @@ def run_diffusers(
 
 def resize_and_crop(input_image: PIL.Image.Image, height: int, width: int):
     input_width, input_height = input_image.size
+
+    # nearest neighbor for upscaling
+    if (input_width * input_height) < (width * height):
+        resample_type = Image.NEAREST
+    # lanczos for downscaling
+    else:
+        resample_type = Image.LANCZOS
+
     if height / width > input_height / input_width:
         adjust_width = int(input_width * height / input_height)
         input_image = input_image.resize((adjust_width, height),
-                                         resample=Image.NEAREST)
+                                         resample=resample_type)
         left = (adjust_width - width) // 2
         right = left + width
         input_image = input_image.crop((left, 0, right, height))
     else:
         adjust_height = int(input_height * width / input_width)
         input_image = input_image.resize((width, adjust_height),
-                                         resample=Image.NEAREST)
+                                         resample=resample_type)
         top = (adjust_height - height) // 2
         bottom = top + height
         input_image = input_image.crop((0, top, width, bottom))

--- a/onnxUI.py
+++ b/onnxUI.py
@@ -317,13 +317,15 @@ def resize_and_crop(input_image: PIL.Image.Image, height: int, width: int):
     input_width, input_height = input_image.size
     if height / width > input_height / input_width:
         adjust_width = int(input_width * height / input_height)
-        input_image = input_image.resize((adjust_width, height))
+        input_image = input_image.resize((adjust_width, height),
+                                         resample=Image.NEAREST)
         left = (adjust_width - width) // 2
         right = left + width
         input_image = input_image.crop((left, 0, right, height))
     else:
         adjust_height = int(input_height * width / input_width)
-        input_image = input_image.resize((width, adjust_height))
+        input_image = input_image.resize((width, adjust_height),
+                                         resample=Image.NEAREST)
         top = (adjust_height - height) // 2
         bottom = top + height
         input_image = input_image.crop((0, top, width, bottom))


### PR DESCRIPTION
bicubic (or lanczos) results in blurry images when increasing image size with img2img, nearest neighbor gives sharp results. may not be preferable when doing inpainting or downscaling though so that needs a bit of testing.


samples images starting from 768x512 going to 1728x1152, using the same settings and prompt at 0.75 denoise.

lanczos (basically the same results as the default bicubic):
![001071-00 (lanczos](https://user-images.githubusercontent.com/16216325/221183964-f4604385-3c27-49c8-923f-5c96d0f8bbe4.png)

nearest neighbor:
![001074-00 (nearest neighbor](https://user-images.githubusercontent.com/16216325/221184057-157c62dc-b25c-485b-b336-1892db949ba2.png)
