### PR TITLE
workaround for prompt_embeds error

### DIFF
--- a/lpw_pipe.py
+++ b/lpw_pipe.py
@@ -362,7 +362,9 @@ def _encode_prompt(
     num_images_per_prompt,
     do_classifier_free_guidance,
     negative_prompt,
-    max_embeddings_multiples=10
+    max_embeddings_multiples=10,
+    prompt_embeds=None,
+    negative_prompt_embeds=None,
 ):
     r"""
     Encodes the prompt into text encoder hidden states.


### PR DESCRIPTION
Should fix the "unexpected keyword argument 'prompt_embeds'" error.